### PR TITLE
feat: show git status in lower left window

### DIFF
--- a/lua/super-commit/git/commands.lua
+++ b/lua/super-commit/git/commands.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+function M.show_command_output(bufnum, command)
+  local output_str =  vim.fn.system(command)
+  local output_table = vim.split(output_str, '\n')
+  vim.api.nvim_buf_set_lines(bufnum, 0, -1, false, output_table)
+end
+
+function M.show_git_status(bufnum)
+  M.show_command_output(bufnum, "git status")
+end
+
+return M

--- a/lua/super-commit/window.lua
+++ b/lua/super-commit/window.lua
@@ -6,7 +6,7 @@ function M.set_autocmd()
   M.augroup = vim.api.nvim_create_augroup('SuperCommitWindow', {})
   vim.api.nvim_create_autocmd({'BufNewFile', 'BufRead'}, {
     group = M.augroup,
-    pattern = '*.txt',
+    pattern = '*.super',
     -- pattern = 'COMMIT_EDITMSG',
     callback = function()
       window_open.double_vertical()

--- a/lua/super-commit/window.lua
+++ b/lua/super-commit/window.lua
@@ -1,4 +1,5 @@
 local window_open = require('super-commit/window/open')
+local git_cmds = require('super-commit/git/commands')
 
 local M = {}
 
@@ -10,6 +11,8 @@ function M.set_autocmd()
     -- pattern = 'COMMIT_EDITMSG',
     callback = function()
       window_open.double_vertical()
+      local bufnum = 4
+      git_cmds.show_git_status(bufnum)
     end,
   })
 end


### PR DESCRIPTION
When we open the super file (*.super), we show the git status in the lower left window. 

* concerns for the future
	how to get window/buffer num consistent regardless of its number
