### PR TITLE
fix: save buffer number in table

### DIFF
--- a/lua/super-commit/window.lua
+++ b/lua/super-commit/window.lua
@@ -10,9 +10,8 @@ function M.set_autocmd()
     pattern = '*.super',
     -- pattern = 'COMMIT_EDITMSG',
     callback = function()
-      window_open.double_vertical()
-      local bufnum = 4
-      git_cmds.show_git_status(bufnum)
+      local bufnum_table = window_open.double_vertical()
+      git_cmds.show_git_status(bufnum_table[3])
     end,
   })
 end

--- a/lua/super-commit/window/open.lua
+++ b/lua/super-commit/window/open.lua
@@ -6,13 +6,19 @@ function M.single_vertical()
 end
 
 function M.double_vertical()
+  local bufnum_1 = vim.api.nvim_get_current_buf();
   vim.cmd('rightbelow vsplit')
   vim.cmd('wincmd l')
   vim.cmd('enew')
+  local bufnum_2 = vim.api.nvim_get_current_buf();
   vim.cmd('wincmd h')
   vim.cmd('rightbelow split')
   vim.cmd('wincmd j')
   vim.cmd('enew')
+  local bufnum_3 = vim.api.nvim_get_current_buf();
+
+  local bufnum_table = {bufnum_1, bufnum_2, bufnum_3}
+  return bufnum_table
 end
 
 return M


### PR DESCRIPTION
We couldn't get consistent buffer numbers.
We save the buffer number consistent with its number in the table.