### PR TITLE
refactor: manage window numbers, buffer numbers, and commands  in public table

### DIFF
--- a/lua/super-commit/git/commands.lua
+++ b/lua/super-commit/git/commands.lua
@@ -23,4 +23,11 @@ function M.show_diff(bufnum, rel_path)
   M.show_output(bufnum, "git diff --cached ".. abs_path)
 end
 
+function M.show_selected_diff()
+    M.show_diff(
+      M.map_table["diff"].bufnum,
+      vim.api.nvim_get_current_line()
+    )
+end
+
 return M

--- a/lua/super-commit/git/commands.lua
+++ b/lua/super-commit/git/commands.lua
@@ -1,4 +1,15 @@
 local M = {}
+M.init_commands = {"status", "filelist", "diff"}
+
+M.map_table = {}
+M.map_table["status"] = {winnum=nil, bufnum=nil, command="git status"}
+M.map_table["filelist"] = {winnum=nil, bufnum=nil,
+                          command="git diff --name-only --cached"}
+local file_select_suggestion = "To show git diff of files, " ..
+                            "select the file path in the window below, " ..
+                            "and press Enter."
+M.map_table["diff"] = {winnum=nil, bufnum=nil,
+                      command="echo " .. file_select_suggestion}
 
 function M.show_output(bufnum, command)
   local output_str =  vim.fn.system(command)
@@ -11,14 +22,5 @@ function M.show_diff(bufnum, rel_path)
   local abs_path = git_root .. "/" .. rel_path
   M.show_output(bufnum, "git diff --cached ".. abs_path)
 end
-
-local file_select_suggestion = "To show git diff of files, " ..
-                            "select the file path in the window below, " ..
-                            "and press Enter."
-
-M.command_table = {}
-M.command_table[2] = "echo " .. file_select_suggestion
-M.command_table[3] = "git status"
-M.command_table[4] = "git diff --name-only --cached"
 
 return M

--- a/lua/super-commit/super-commit.lua
+++ b/lua/super-commit/super-commit.lua
@@ -13,19 +13,12 @@ function M.init()
   end
 end
 
-function M.show_selected_diff()
-    git_cmds.show_diff(
-        map_table["diff"].bufnum,
-        vim.api.nvim_get_current_line()
-    )
-end
-
 function M.autocmd_callback()
   M.init()
   vim.api.nvim_set_keymap(
       'n',
       '<CR>',
-      '<Cmd>lua require("super-commit/super-commit")' ..
+      '<Cmd>lua require("super-commit/git/commands")' ..
       '.show_selected_diff()<CR>',
       { noremap = true, silent = true }
   )

--- a/lua/super-commit/super-commit.lua
+++ b/lua/super-commit/super-commit.lua
@@ -1,20 +1,21 @@
 local window_open = require('super-commit/window/open')
+
 local git_cmds = require('super-commit/git/commands')
+local init_commands = git_cmds.init_commands
+local map_table = git_cmds.map_table
 
 local M = {}
 
 function M.init()
   window_open.setup()
-  local bufnum_table = window_open.bufnum_table
-  local command_table = git_cmds.command_table
-  for k, cmd in pairs(command_table) do
-    git_cmds.show_output(bufnum_table[k], cmd)
+  for _, k in pairs(init_commands) do
+    git_cmds.show_output(map_table[k].bufnum, map_table[k].command)
   end
 end
 
 function M.show_selected_diff()
     git_cmds.show_diff(
-        window_open.bufnum_table[2],
+        map_table["diff"].bufnum,
         vim.api.nvim_get_current_line()
     )
 end

--- a/lua/super-commit/window/open.lua
+++ b/lua/super-commit/window/open.lua
@@ -1,3 +1,7 @@
+local git_cmds = require('super-commit/git/commands')
+local map_table = git_cmds.map_table
+local init_commands = git_cmds.init_commands
+
 local M = {}
 
 function M.single_vertical()
@@ -5,26 +9,27 @@ function M.single_vertical()
   vim.cmd('enew')
 end
 
-M.bufnum_table ={}
+local function set_current_number(k)
+  map_table[k].bufnum =  vim.api.nvim_get_current_buf();
+  map_table[k].winnum =  vim.api.nvim_win_get_number(0);
+end
 
 function M.setup()
-  local bufnum_1 = vim.api.nvim_get_current_buf();
   vim.cmd('rightbelow vsplit')
   vim.cmd('wincmd l')
   vim.cmd('enew')
-  local bufnum_2 = vim.api.nvim_get_current_buf();
+  set_current_number(init_commands[3])
   vim.cmd('wincmd h')
   vim.cmd('rightbelow split')
   vim.cmd('wincmd j')
   vim.cmd('enew')
-  local bufnum_3 = vim.api.nvim_get_current_buf();
+  set_current_number(init_commands[1])
   vim.cmd('wincmd l')
   vim.cmd('rightbelow split')
   vim.cmd('wincmd j')
   vim.cmd('enew')
-  local bufnum_4 = vim.api.nvim_get_current_buf();
+  set_current_number(init_commands[2])
 
-  M.bufnum_table = {bufnum_1, bufnum_2, bufnum_3, bufnum_4}
 end
 
 return M


### PR DESCRIPTION
Confirmed the plugin behavior didn't change after refactoring.