### PR TITLE
Feat/auto adjust winsize

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -10,5 +10,6 @@ globals = {
   "print",
   "require",
   "vim",
-  "pairs"
+  "pairs",
+  "math"
 }

--- a/lua/super-commit/git/commands.lua
+++ b/lua/super-commit/git/commands.lua
@@ -6,7 +6,7 @@ M.map_table["status"] = {winnum=nil, bufnum=nil, command="git status"}
 M.map_table["filelist"] = {winnum=nil, bufnum=nil,
                           command="git diff --name-only --cached"}
 local file_select_suggestion = "To show git diff of files, " ..
-                            "select the file path in the window below, " ..
+                            "select the file path shown above, " ..
                             "and press Enter."
 M.map_table["diff"] = {winnum=nil, bufnum=nil,
                       command="echo " .. file_select_suggestion}

--- a/lua/super-commit/super-commit.lua
+++ b/lua/super-commit/super-commit.lua
@@ -9,7 +9,9 @@ local M = {}
 function M.init()
   window_open.setup()
   for _, k in pairs(init_commands) do
-    git_cmds.show_output(map_table[k].bufnum, map_table[k].command)
+    if map_table[k].bufnum then
+      git_cmds.show_output(map_table[k].bufnum, map_table[k].command)
+    end
   end
 end
 

--- a/lua/super-commit/window/open.lua
+++ b/lua/super-commit/window/open.lua
@@ -1,6 +1,5 @@
 local git_cmds = require('super-commit/git/commands')
 local map_table = git_cmds.map_table
-local init_commands = git_cmds.init_commands
 
 local M = {}
 
@@ -9,22 +8,105 @@ local function set_current_number(k)
   map_table[k].winnum =  vim.api.nvim_win_get_number(0);
 end
 
-function M.setup()
-  vim.cmd('rightbelow vsplit')
-  vim.cmd('wincmd l')
-  vim.cmd('enew')
-  set_current_number(init_commands[2])
-  vim.cmd('wincmd h')
-  vim.cmd('rightbelow split')
-  vim.cmd('wincmd j')
-  vim.cmd('enew')
-  set_current_number(init_commands[1])
-  vim.cmd('wincmd l')
-  vim.cmd('rightbelow split')
-  vim.cmd('wincmd j')
-  vim.cmd('enew')
-  set_current_number(init_commands[3])
+local layout_2x2 = {
+  {'commit', 'filelist'},
+  {'status', 'diff'}
+}
 
+local layout_3x1 = {
+  {'commit'},
+  {'filelist'},
+  {'diff'},
+}
+
+local required_editor_width = 80
+local required_editor_height = 20
+
+local function split_by_ratio(init_cmd, ratio, is_above_split)
+  ratio = ratio or 0.5
+  local split = 'below'
+  if is_above_split then
+    split = 'above'
+  end
+  vim.api.nvim_open_win(0, true, {
+    split=split,
+    win=0,
+    height = math.floor(vim.api.nvim_win_get_height(0)*ratio),
+  })
+
+  vim.cmd('enew')
+  set_current_number(init_cmd)
+
+  if split == 'below' then
+    vim.cmd('wincmd k')
+  else
+    vim.cmd('wincmd j')
+  end
+end
+
+local function vsplit_by_ratio(init_cmd, ratio, is_left_split)
+  ratio = ratio or 0.5
+  local split = 'right'
+  if is_left_split then
+    split = 'left'
+  end
+  vim.api.nvim_open_win(0, true, {
+    split=split,
+    win=0,
+    width = math.floor(vim.api.nvim_win_get_width(0)*ratio),
+  })
+
+  vim.cmd('enew')
+  set_current_number(init_cmd)
+
+  if split == 'right' then
+    vim.cmd('wincmd h')
+  else
+    vim.cmd('wincmd l')
+  end
+end
+
+local function open_2x2()
+  split_by_ratio(layout_2x2[2][1], 0.6)
+  vsplit_by_ratio(layout_2x2[1][2], 0.5)
+  vim.cmd('wincmd j')
+  vsplit_by_ratio(layout_2x2[2][2], 0.5)
+  vim.api.nvim_win_set_cursor(0, {1, 0})
+end
+
+local function open_3x1()
+  split_by_ratio(layout_3x1[2][1], 0.8)
+  -- ratio should be the sum of the 2nd & 3rd row
+  vim.cmd('wincmd j')
+  split_by_ratio(layout_3x1[3][1], 0.6)
+  vim.api.nvim_win_set_cursor(0, {1, 0})
+end
+
+local function is_sufficient_width()
+  local current_width = vim.api.nvim_win_get_width(0)
+  if current_width < required_editor_width then
+    return false
+  end
+  return true
+end
+
+local function is_sufficient_height()
+  local current_height = vim.api.nvim_win_get_height(0)
+  if current_height < required_editor_height then
+    return false
+  end
+  return true
+end
+
+function M.setup()
+  if not is_sufficient_height() then
+    return
+  end
+  if not is_sufficient_width() then
+    open_3x1()
+    return
+  end
+  open_2x2()
 end
 
 return M

--- a/lua/super-commit/window/open.lua
+++ b/lua/super-commit/window/open.lua
@@ -4,11 +4,6 @@ local init_commands = git_cmds.init_commands
 
 local M = {}
 
-function M.single_vertical()
-  vim.cmd('vsplit')
-  vim.cmd('enew')
-end
-
 local function set_current_number(k)
   map_table[k].bufnum =  vim.api.nvim_get_current_buf();
   map_table[k].winnum =  vim.api.nvim_win_get_number(0);

--- a/lua/super-commit/window/open.lua
+++ b/lua/super-commit/window/open.lua
@@ -13,7 +13,7 @@ function M.setup()
   vim.cmd('rightbelow vsplit')
   vim.cmd('wincmd l')
   vim.cmd('enew')
-  set_current_number(init_commands[3])
+  set_current_number(init_commands[2])
   vim.cmd('wincmd h')
   vim.cmd('rightbelow split')
   vim.cmd('wincmd j')
@@ -23,7 +23,7 @@ function M.setup()
   vim.cmd('rightbelow split')
   vim.cmd('wincmd j')
   vim.cmd('enew')
-  set_current_number(init_commands[2])
+  set_current_number(init_commands[3])
 
 end
 


### PR DESCRIPTION
setup() in window/open.lua tries to split the window into 2x2.
In case the editor doesn't have enough width, split the window into 3x1.
Furthermore, in case of a lack of editor height, leave the window without any splits.
