### PR TITLE
Refactor: Split init-cmds table

### DIFF
--- a/lua/super-commit/git/commands.lua
+++ b/lua/super-commit/git/commands.lua
@@ -1,20 +1,26 @@
 local M = {}
-M.init_cmds = {"status", "filelist", "diff"}
 
 M.map_table = {}
-M.map_table["status"] = {winid=nil, bufid=nil, cmd="git status"}
-M.map_table["filelist"] = {winid=nil, bufid=nil,
-                          cmd="git diff --name-only --cached"}
+M.map_table["status"] = {winid=nil, bufid=nil}
+M.map_table["filelist"] = {winid=nil, bufid=nil}
+M.map_table["diff"] = {winid=nil, bufid=nil}
+
+local init_cmds = {}
+init_cmds["status"] = "git status"
+init_cmds["filelist"] = "git diff --name-only --cached"
 local file_select_suggestion = "To show git diff of files, " ..
                             "select the file path shown above, " ..
                             "and press Enter."
-M.map_table["diff"] = {winid=nil, bufid=nil,
-                      cmd="echo " .. file_select_suggestion}
+init_cmds["diff"] = "echo " .. file_select_suggestion
 
 function M.show_output(bufid, cmd)
   local output_str =  vim.fn.system(cmd)
   local output_table = vim.split(output_str, '\n')
   vim.api.nvim_buf_set_lines(bufid, 0, -1, false, output_table)
+end
+
+function M.show_init_cmd(k)
+  M.show_output(M.map_table[k].bufid, init_cmds[k])
 end
 
 function M.show_diff(bufid, rel_path)

--- a/lua/super-commit/super-commit.lua
+++ b/lua/super-commit/super-commit.lua
@@ -1,16 +1,16 @@
 local window_open = require('super-commit/window/open')
 
 local git_cmds = require('super-commit/git/commands')
-local init_cmds = git_cmds.init_cmds
 local map_table = git_cmds.map_table
 
 local M = {}
+local git_keys = {"status", "filelist", "diff"}
 
 function M.init()
   window_open.setup()
-  for _, k in pairs(init_cmds) do
+  for _, k in pairs(git_keys) do
     if map_table[k].bufid then
-      git_cmds.show_output(map_table[k].bufid, map_table[k].cmd)
+      git_cmds.show_init_cmd(k)
     end
   end
 end


### PR DESCRIPTION
Split `init-cmds` table from `map_table` and localize it in git module(git/commands.lua).

Due to this splitting, add `show_init_cmd` function in git/commands.lua.